### PR TITLE
Add MAINTAIN table privilege, added in Postgres 17

### DIFF
--- a/postgresql/helpers.go
+++ b/postgresql/helpers.go
@@ -251,7 +251,7 @@ func sliceContainsStr(haystack []string, needle string) bool {
 // see: https://www.postgresql.org/docs/current/sql-grant.html
 var allowedPrivileges = map[string][]string{
 	"database":             {"ALL", "CREATE", "CONNECT", "TEMPORARY"},
-	"table":                {"ALL", "SELECT", "INSERT", "UPDATE", "DELETE", "TRUNCATE", "REFERENCES", "TRIGGER"},
+	"table":                {"ALL", "SELECT", "INSERT", "UPDATE", "DELETE", "TRUNCATE", "REFERENCES", "TRIGGER", "MAINTAIN"},
 	"sequence":             {"ALL", "USAGE", "SELECT", "UPDATE"},
 	"schema":               {"ALL", "CREATE", "USAGE"},
 	"function":             {"ALL", "EXECUTE"},


### PR DESCRIPTION
The `MAINTAIN` privilege is added in Postgres 17 (see [here](https://www.postgresql.org/docs/17/sql-grant.html)). Without it, even the owner of the table cannot perform tasks like `VACUUM`, `ANALYZE`, or `REINDEX`.

Upon adding this privilege, we got this error:

```
Error: MAINTAIN is not an allowed privilege for object type table
```

Upon a closer investigation, the list of table privileges in `allowedPrivileges` needs to be augmented.

The following query on Postgres 17 shows all valid privilesges for different types of Postgres objects:

```sql
with t(col) as (
  select unnest(array['c', 'd', 'f', 'F', 'l', 'L', 'n', 'p', 'r', 's', 'S', 't', 'T'])
)
select col, array_agg(privilege_type) as privileges
from t
join lateral aclexplode(acldefault(col::"char", 0)) as a on true
group by col;
```

Result:
<img width="1002" height="457" alt="image" src="https://github.com/user-attachments/assets/90c87f10-325e-47f0-a627-a31b27e26ada" />
